### PR TITLE
Release 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# C++ objects and libs
+
+*.slo
+*.lo
+*.o
+*.a
+*.la
+*.lai
+*.so
+*.dll
+*.dylib
+
+# Qt-es
+
+/.qmake.cache
+/.qmake.stash
+*.pro.user
+*.pro.user.*
+*.qbs.user
+*.qbs.user.*
+*.moc
+moc_*.cpp
+qrc_*.cpp
+ui_*.h
+Makefile*
+*build-*
+
+# QtCreator
+
+*.autosave
+
+# QtCtreator Qml
+*.qmlproject.user
+*.qmlproject.user.*
+
+# QtCtreator CMake
+CMakeLists.txt.user
+
+# Project specific
+third_party/openh264-bin/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/openh264"]
+	path = third_party/openh264
+	url = git@github.com:cisco/openh264.git

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+ 
+OpenH264 VLC Plugin
+===================
+OpenH264 VLC Plugin is a plugin module for VLC enabling use of OpenH264 codec (encoder and decoder) in LibVLC and VLC media player.
+
+Loading plug-in module in LibVLC and VLC media player
+-----------------------------------------------------
+For LibVLC < 2.0.0 you can add `--plugin-path` option to other options with the directory where compiled library is while creating LibVLC instance.
+
+For LibVLC >= 2.0.0 you can set `VLC_PLUGIN_PATH` environment variable to the directory where compiled library is before creating LibVLC instance.
+
+For all LibVLC you can just copy compiled lib in `plugins/` directory where LibVLC plugins are. Note: this will make module accessible system-wide.
+
+Note: plugin file **must** be named as `libopenh264_plugin.[so/dll]`; please refer to [this guide](https://wiki.videolan.org/Documentation:VLC_Modules_Loading/#How_does_the_loading_of_modules_happen)  for more info.
+
+
+Selecting encoder in LibVLC or VLC media player
+-----------------------------------------------
+When setting up `transcode` module in LibVLC or VLC media player use:
+
+    #transcode{vcodec=h264,venc=OpenH264{}, ... }
+to select OpenH264 encoder
+
+Selecting decoder in LibVLC or VLC media player
+-----------------------------------------------
+When setting up media options in LibVLC use:
+```
+libvlc_media_add_option(media,":codec=OpenH264");
+```
+to select OpenH264 decoder.
+
+You can add `:codec=OpenH264` option in VLC media player while opening file (use Media -> Open Multiple Files ...-> Show more options -> Edit Options section to add options).
+
+License
+-------
+BSD, see `LICENSE` file for details.

--- a/codec_openh264.c
+++ b/codec_openh264.c
@@ -30,6 +30,9 @@
 #   define INT64_C(c)	c ## L
 #endif
 
+#define OPENH264_VERSION(a, b, c) (((a) << 16) + ((b) << 8) + (c))
+#define OPENH264_CURRENT_VER OPENH264_VERSION(OPENH264_MAJOR, OPENH264_MINOR, OPENH264_REVISION)
+
 /*****************************************************************************
  * Preamble
  *****************************************************************************/
@@ -48,6 +51,7 @@
 #include <limits.h>
 
 #include "codec_api.h"
+#include "codec_ver.h"
 
 /*****************************************************************************
  * Local prototypes
@@ -155,7 +159,9 @@ static int OpenDecoder( vlc_object_t *p_this )
     p_sys->i_size = 0;
 
     p_sys->sDecParam->sVideoProperty.size = sizeof (p_sys->sDecParam->sVideoProperty);
-    //p_sys->sDecParam->eOutputColorFormat = videoFormatI420;
+#if OPENH264_CURRENT_VER < OPENH264_VERSION(1, 6, 0)
+    p_sys->sDecParam->eOutputColorFormat = videoFormatI420;
+#endif
     p_sys->sDecParam->uiTargetDqLayer = (uint8_t) - 1;
     p_sys->sDecParam->eEcActiveIdc = ERROR_CON_SLICE_COPY;
     p_sys->sDecParam->sVideoProperty.eVideoBsType = VIDEO_BITSTREAM_DEFAULT;

--- a/codec_openh264.c
+++ b/codec_openh264.c
@@ -47,6 +47,32 @@
 /*****************************************************************************
  * Local prototypes
  *****************************************************************************/
+
+static int openh264_to_vlc_log(int openh264_log_level)
+{
+    switch (openh264_log_level) {
+    case WELS_LOG_QUIET:
+        return VLC_MSG_DBG;
+    case WELS_LOG_ERROR:
+        return VLC_MSG_ERR;
+    case WELS_LOG_WARNING:
+        return VLC_MSG_WARN;
+    case WELS_LOG_INFO:
+        return VLC_MSG_INFO;
+    case WELS_LOG_DEBUG:
+        return VLC_MSG_DBG;
+    case WELS_LOG_DETAIL:
+        return VLC_MSG_DBG;
+    default:
+        return VLC_MSG_DBG;
+    }
+}
+
+static void openh264_vlc_log(void* context, int level, const char* message)
+{
+    vlc_Log( context, openh264_to_vlc_log(level), MODULE_STRING, message );
+}
+
 static int  OpenDecoder   ( vlc_object_t * );
 static void CloseDecoder  ( vlc_object_t * );
 static picture_t *DecodeBlock  ( decoder_t *, block_t ** );
@@ -172,6 +198,13 @@ static int OpenDecoder( vlc_object_t *p_this )
 
     int32_t iErrorConMethod = (int32_t) ERROR_CON_SLICE_MV_COPY_CROSS_IDR_FREEZE_RES_CHANGE;
     (*p_sys->pDecoder)->SetOption(p_sys->pDecoder, DECODER_OPTION_ERROR_CON_IDC, &iErrorConMethod);
+
+    int log_level = WELS_LOG_DETAIL;
+    WelsTraceCallback callback_function;
+    callback_function = openh264_vlc_log;
+    (*p_sys->pDecoder)->SetOption(p_sys->pDecoder, DECODER_OPTION_TRACE_LEVEL, &log_level);
+    (*p_sys->pDecoder)->SetOption(p_sys->pDecoder, DECODER_OPTION_TRACE_CALLBACK, (void*)&callback_function);
+    (*p_sys->pDecoder)->SetOption(p_sys->pDecoder, DECODER_OPTION_TRACE_CALLBACK_CONTEXT, (void*)&p_dec);
 
     msg_Info(p_dec, "OpenH264 decoder opened!");
     return VLC_SUCCESS;

--- a/codec_openh264.c
+++ b/codec_openh264.c
@@ -29,10 +29,6 @@
 #ifndef INT64_C
 #   define INT64_C(c)	c ## L
 #endif
-#ifndef N_
-#   define N_(str)           gettext_noop (str)
-#   define gettext_noop(str) (str)
-#endif
 
 /*****************************************************************************
  * Preamble
@@ -72,13 +68,13 @@ vlc_module_begin ()
     set_subcategory( SUBCAT_INPUT_VCODEC )
     set_shortname( "OpenH264 codec" )
 
-    set_description( N_("OpenH264 encoder") )
+    set_description( "OpenH264 encoder" )
     set_capability( "encoder", 0 )
     set_callbacks( OpenEncoder, CloseEncoder )
     add_shortcut( "OpenH264" )
 
     add_submodule ()
-    set_description( N_("OpenH264 decoder") )
+    set_description( "OpenH264 decoder" )
     set_capability( "decoder", 0 )
     set_callbacks( OpenDecoder, CloseDecoder )
     add_shortcut( "OpenH264" )

--- a/codec_openh264.c
+++ b/codec_openh264.c
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2016, A.ST.I.M. S.r.l.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #define __PLUGIN__
 #define MODULE_STRING "OpenH264"
 

--- a/codec_openh264.c
+++ b/codec_openh264.c
@@ -472,8 +472,9 @@ static int OpenEncoder( vlc_object_t *p_this )
     p_sys->sSvcParam->sSpatialLayers[0].fFrameRate         = 25;
     p_sys->sSvcParam->sSpatialLayers[0].iSpatialBitrate    = 2500000;
     p_sys->sSvcParam->sSpatialLayers[0].iMaxSpatialBitrate    = UNSPECIFIED_BIT_RATE;
-    //p_sys->sSvcParam->sSpatialLayers[0].sSliceCfg.uiSliceMode = SM_SINGLE_SLICE;
-
+#if OPENH264_CURRENT_VER < OPENH264_VERSION(1, 6, 0)
+    p_sys->sSvcParam->sSpatialLayers[0].sSliceCfg.uiSliceMode = SM_SINGLE_SLICE;
+#endif
     if (cmResultSuccess != (*p_sys->pSVCEncoder)->InitializeExt(p_sys->pSVCEncoder, p_sys->sSvcParam)) { // SVC encoder initialization
         msg_Err(p_enc, "SVC encoder Initialize failed");
         return VLC_EGENERIC;

--- a/codec_openh264.c
+++ b/codec_openh264.c
@@ -1,34 +1,5 @@
 #define __PLUGIN__
 #define MODULE_STRING "OpenH264"
-#define HAVE_GMTIME_R
-#define HAVE_LOCALTIME_R
-#define HAVE_LLDIV
-#define HAVE_USELOCALE
-#define HAVE_STRCASECMP
-#define HAVE_STRDUP
-#define HAVE_STRVERSCMP
-#define HAVE_STRNLEN
-#define HAVE_STRNDUP
-#define HAVE_STRSEP
-#define HAVE_STRTOK_R
-#define HAVE_ATOF
-#define HAVE_ATOLL
-#define HAVE_STRTOF
-#define HAVE_STRTOLL
-#define HAVE_GETENV
-#define HAVE_SETENV
-#define HAVE_POSIX_MEMALIGN
-#define HAVE_NRAND48
-#define HAVE_SWAB
-#define HAVE_STRCASESTR
-#define LIBVLC_USE_PTHREAD_CANCEL
-
-#ifdef __MINGW32__
-#   define HAVE_GETPID
-#endif
-#ifndef INT64_C
-#   define INT64_C(c)	c ## L
-#endif
 
 #define OPENH264_VERSION(a, b, c) (((a) << 16) + ((b) << 8) + (c))
 #define OPENH264_CURRENT_VER OPENH264_VERSION(OPENH264_MAJOR, OPENH264_MINOR, OPENH264_REVISION)
@@ -37,18 +8,12 @@
  * Preamble
  *****************************************************************************/
 
-#ifndef __MINGW32__
-#   include "vlc_fixups.h"
-#endif
 #include "vlc_common.h"
 #include "vlc_plugin.h"
 #include "vlc_codec.h"
 #include "vlc_block.h"
 #include "vlc_sout.h"
 #include "vlc_input.h"
-
-#include <assert.h>
-#include <limits.h>
 
 #include "codec_api.h"
 #include "codec_ver.h"

--- a/codec_openh264.cpp
+++ b/codec_openh264.cpp
@@ -1,0 +1,626 @@
+#define __PLUGIN__
+#define MODULE_STRING "OpenH264"
+#define HAVE_GMTIME_R
+#define HAVE_LOCALTIME_R
+#define HAVE_LLDIV
+#define HAVE_USELOCALE
+#define HAVE_STRCASECMP
+#define HAVE_STRDUP
+#define HAVE_STRVERSCMP
+#define HAVE_STRNLEN
+#define HAVE_STRNDUP
+#define HAVE_STRSEP
+#define HAVE_STRTOK_R
+#define HAVE_ATOF
+#define HAVE_ATOLL
+#define HAVE_STRTOF
+#define HAVE_STRTOLL
+#define HAVE_GETENV
+#define HAVE_SETENV
+#define HAVE_POSIX_MEMALIGN
+#define HAVE_NRAND48
+#define HAVE_SWAB
+#define HAVE_STRCASESTR
+
+#ifdef __MINGW32__
+#   define HAVE_GETPID
+#endif
+#ifndef INT64_C
+#   define INT64_C(c)	c ## L
+#endif
+#ifndef N_
+#   define N_(str)           gettext_noop (str)
+#   define gettext_noop(str) (str)
+#endif
+
+/*****************************************************************************
+ * Preamble
+ *****************************************************************************/
+
+#ifndef __MINGW32__
+#   include "vlc_fixups.h"
+#endif
+#include "vlc_common.h"
+#include "vlc_plugin.h"
+#include "vlc_codec.h"
+#include "vlc_block.h"
+#include "vlc_sout.h"
+#include "vlc_input.h"
+
+#include <assert.h>
+#include <limits.h>
+
+#include "codec_api.h"
+
+/*****************************************************************************
+ * Local prototypes
+ *****************************************************************************/
+static int  OpenDecoder   ( vlc_object_t * );
+static void CloseDecoder  ( vlc_object_t * );
+static picture_t *DecodeBlock  ( decoder_t *, block_t ** );
+
+static int  OpenEncoder( vlc_object_t *p_this );
+static void CloseEncoder( vlc_object_t *p_this );
+static block_t *Encode( encoder_t *p_enc, picture_t *p_pict );
+
+/*****************************************************************************
+ * Module descriptor
+ *****************************************************************************/
+vlc_module_begin ()
+    set_category( CAT_INPUT )
+    set_subcategory( SUBCAT_INPUT_VCODEC )
+    set_shortname( "OpenH264 codec" )
+
+    set_description( N_("OpenH264 encoder") )
+    set_capability( "encoder", 0 )
+    set_callbacks( OpenEncoder, CloseEncoder )
+    add_shortcut( "OpenH264" )
+
+    add_submodule ()
+    set_description( N_("OpenH264 decoder") )
+    set_capability( "decoder", 0 )
+    set_callbacks( OpenDecoder, CloseDecoder )
+    add_shortcut( "OpenH264" )
+vlc_module_end ()
+
+/*****************************************************************************
+ * decoder_sys_t : theora decoder descriptor
+ *****************************************************************************/
+struct decoder_sys_t
+{
+    ISVCDecoder* pDecoder;
+    SDecodingParam* sDecParam;
+    SBufferInfo* sDstBufInfo;
+    video_format_t out_fmt;
+    unsigned long long uiTimeStamp;
+
+    bool b_withDelimiter;
+    uint8_t* p_buff;
+    unsigned long long i_size;
+};
+
+/*****************************************************************************
+ * OpenDecoder: probe the decoder and return score
+ *****************************************************************************/
+static int OpenDecoder( vlc_object_t *p_this )
+{
+    decoder_t *p_dec = (decoder_t*)p_this;
+    decoder_sys_t *p_sys;
+
+    if( p_dec->fmt_in.i_codec != VLC_CODEC_H264 )
+    {
+        return VLC_EGENERIC;
+    }
+
+    /* Allocate the memory needed to store the decoder's structure */
+    if( ( p_sys = (decoder_sys_t*)malloc(sizeof(decoder_sys_t)) ) == NULL )
+        return VLC_ENOMEM;
+    p_dec->p_sys = p_sys;
+
+    p_dec->fmt_out.i_cat = VIDEO_ES;
+    p_dec->fmt_out.i_codec = VLC_CODEC_I420;
+    p_dec->pf_decode_video = (picture_t *(*)( decoder_t *, block_t ** )) DecodeBlock;
+    p_dec->pf_packetize  =  NULL;
+    p_dec->pf_decode_audio = NULL;
+
+    p_dec->fmt_out.video.i_chroma = VLC_CODEC_I420;
+    p_dec->fmt_out.video.i_visible_width = p_dec->fmt_out.video.i_width = p_dec->fmt_in.video.i_width;
+    p_dec->fmt_out.video.i_visible_height = p_dec->fmt_out.video.i_height = p_dec->fmt_in.video.i_height;
+    p_dec->fmt_out.video.i_sar_num = 1;
+    p_dec->fmt_out.video.i_sar_den = 1;
+
+    if( p_dec->fmt_in.video.i_frame_rate > 0 &&
+        p_dec->fmt_in.video.i_frame_rate_base > 0 )
+    {
+        p_dec->fmt_out.video.i_frame_rate =
+            p_dec->fmt_in.video.i_frame_rate;
+        p_dec->fmt_out.video.i_frame_rate_base =
+            p_dec->fmt_in.video.i_frame_rate_base;
+    }
+
+    p_sys->pDecoder = NULL;
+    if(WelsCreateDecoder (&p_sys->pDecoder))
+    {
+        msg_Err(p_dec, "WelsCreateDecoder failed!");
+        return VLC_ENOMEM;
+    }
+
+    p_sys->sDecParam = new SDecodingParam;
+    if (p_sys->sDecParam == NULL)
+    {
+        msg_Err(p_dec, "Can't allocate memory for SDecodingParam");
+        return VLC_ENOMEM;
+    }
+    p_sys->uiTimeStamp = 0;
+
+    p_sys->b_withDelimiter = false;
+    p_sys->p_buff = NULL;
+    p_sys->i_size = 0;
+
+    p_sys->sDecParam->sVideoProperty.size = sizeof (p_sys->sDecParam->sVideoProperty);
+    p_sys->sDecParam->eOutputColorFormat = videoFormatI420;
+    p_sys->sDecParam->uiTargetDqLayer = (uint8_t) - 1;
+    p_sys->sDecParam->eEcActiveIdc = ERROR_CON_SLICE_COPY;
+    p_sys->sDecParam->sVideoProperty.eVideoBsType = VIDEO_BITSTREAM_DEFAULT;
+    p_sys->sDecParam->bParseOnly = false;
+
+    p_sys->out_fmt = p_dec->fmt_out.video;
+
+    p_sys->sDstBufInfo = new SBufferInfo;
+    memset (p_sys->sDstBufInfo, 0, sizeof (SBufferInfo));
+
+    int ret = p_sys->pDecoder->Initialize(p_sys->sDecParam);
+    if (cmResultSuccess != ret) {
+        printf ("Decoder initialization failed with error: %d.\n", ret);
+        return VLC_ENOMEM;
+    }
+
+    int32_t iErrorConMethod = (int32_t) ERROR_CON_SLICE_MV_COPY_CROSS_IDR_FREEZE_RES_CHANGE;
+    p_sys->pDecoder->SetOption (DECODER_OPTION_ERROR_CON_IDC, &iErrorConMethod);
+
+    msg_Info(p_dec, "OpenH264 decoder opened!");
+    return VLC_SUCCESS;
+}
+
+static size_t getNal(uint8_t* p_buf, uint8_t* p_bufEnd, uint8_t** p_nalStart, uint8_t** p_nalEnd)
+{
+    *p_nalStart = p_buf;
+    while(*p_nalStart + 2 < p_bufEnd)
+    {
+        if ((*p_nalStart)[0] == 0 && (*p_nalStart)[1] == 0 && (*p_nalStart)[2] == 1)
+        {
+            break;
+        }
+        (*p_nalStart)++;
+    }
+    if (*p_nalStart + 2 == p_bufEnd)
+    {
+        *p_nalStart = p_bufEnd;
+        *p_nalEnd = p_bufEnd;
+        return 0;
+    }
+
+    *p_nalEnd = *p_nalStart + 3;
+    while(*p_nalEnd + 2 < p_bufEnd)
+    {
+        if ((*p_nalEnd)[0] == 0 && (*p_nalEnd)[1] == 0 && (*p_nalEnd)[2] == 1)
+        {
+            break;
+        }
+        (*p_nalEnd)++;
+    }
+    if (*p_nalEnd + 2 == p_bufEnd)
+        *p_nalEnd = p_bufEnd;
+    return *p_nalEnd - *p_nalStart;
+}
+
+static void getNalType(uint8_t* p_nal, int* i_type)
+{
+    *i_type = (int) p_nal[3] & 0x1F; // & 00011111
+}
+
+/****************************************************************************
+ * DecodeBlock: the whole thing
+ ****************************************************************************/
+static picture_t *DecodeBlock( decoder_t *p_dec, block_t **pp_block )
+{
+    decoder_sys_t *p_sys = p_dec->p_sys;
+    block_t *p_block;
+
+    if( !pp_block || !*pp_block ) return NULL;
+    p_block = *pp_block;
+
+    int32_t iBufPos = 0;
+    int32_t iSliceIndex = 0;
+    int32_t iSliceSize = 0;
+
+    uint8_t* pData[3] = {NULL};
+
+    picture_t *p_picture = NULL;
+
+    uint8_t* nalStart = p_block->p_buffer;
+    uint8_t* nalEnd = NULL;
+    size_t nalLength = 0;
+    int nalType = -1;
+    int ret = -1;
+
+    uint8_t*    sliceStart = NULL;
+    uint8_t*    sliceEnd = NULL;
+    size_t      sliceLength = 0;
+    int     sliceType = -1;
+
+    p_sys->uiTimeStamp = p_block->i_pts;
+    p_sys->sDstBufInfo->uiInBsTimeStamp = p_sys->uiTimeStamp;
+    while (nalStart < &(p_block->p_buffer[p_block->i_buffer]))     // look through all buffer
+    {
+        if (!p_sys->b_withDelimiter)
+        {
+            nalLength = getNal(nalStart, &(p_block->p_buffer[p_block->i_buffer]), &nalStart, &nalEnd);
+            if (nalLength > 0)
+            {
+                getNalType(nalStart, &nalType);
+                switch(nalType)
+                {
+                case 9:     // NAL_DELIMETER
+                    p_sys->b_withDelimiter = true;      //working with delimeters
+                    break;
+                case NAL_SPS:
+                case NAL_PPS:
+                case NAL_SLICE_IDR:
+                case NAL_SLICE:
+                    ret = p_sys->pDecoder->DecodeFrameNoDelay (nalStart, nalLength, pData, p_sys->sDstBufInfo);
+                    if (dsErrorFree != ret)
+                    {
+                        printf("some error in decoding :( %d\n", ret);
+                    }
+                    break;
+                default:
+                    printf("Unknown NAL unit type: %d !\n", nalType);
+                    break;
+                }
+            }
+        }
+        else        //(!p_sys->b_withDelimiter)
+        {
+            uint8_t* tmp_nalStart = p_block->p_buffer;
+            nalLength = getNal(nalStart, &(p_block->p_buffer[p_block->i_buffer]), &tmp_nalStart, &nalEnd);
+            if (nalLength > 0)
+            {
+                getNalType(tmp_nalStart, &nalType);
+                switch (nalType)
+                {
+                case 9: // NAL_DELIMETER
+                    // must copy everything from buffer before delimiter!
+                    p_sys->p_buff = (uint8_t*)realloc(p_sys->p_buff, p_sys->i_size + (tmp_nalStart - nalStart));
+                    memcpy(&(p_sys->p_buff[p_sys->i_size]), nalStart, tmp_nalStart - nalStart);
+                    p_sys->i_size += tmp_nalStart - nalStart;
+
+                    // PROCESS SAVED BUFFER!
+                    sliceStart = p_sys->p_buff;
+                    while (sliceStart < &(p_sys->p_buff[p_sys->i_size]))     // look through all saved buffer
+                    {
+                        sliceLength = getNal(sliceStart, &(p_sys->p_buff[p_sys->i_size]), &sliceStart, &sliceEnd);
+                        if (sliceLength > 0)
+                        {
+                            getNalType(sliceStart, &sliceType);
+                            switch(sliceType)
+                            {
+                            case 9:     // NAL_DELIMETER
+                                printf("SHOULD NEVER HAPPEN! :(\n");
+                                break;
+                            case NAL_SPS:
+                            case NAL_PPS:
+                            case NAL_SLICE_IDR:
+                            case NAL_SLICE:
+                                ret = p_sys->pDecoder->DecodeFrameNoDelay (sliceStart, sliceLength, pData, p_sys->sDstBufInfo);
+                                if (dsErrorFree != ret)
+                                {
+                                    printf("some error in decoding :( %d\n", ret);
+                                }
+                                break;
+                            default:
+                                printf("Unknown NAL unit type: %d !\n", nalType);
+                                break;
+                            }
+                        }
+                        sliceStart = sliceEnd;
+                    }
+                    free(p_sys->p_buff);
+                    p_sys->p_buff = NULL;
+                    p_sys->i_size = 0;
+                    nalStart = nalEnd;
+                    break;
+                default:
+                    break;
+                }
+            }
+            p_sys->p_buff = (uint8_t*)realloc(p_sys->p_buff, p_sys->i_size + (nalEnd - nalStart));
+            memcpy(&(p_sys->p_buff[p_sys->i_size]), nalStart, nalEnd - nalStart);
+            p_sys->i_size += nalEnd - nalStart;
+        }
+        nalStart = nalEnd;
+    }
+
+    // walkaround for RTSP stream when picture size is availble only in PPS
+    // also it is good idea to update resolution woth new PPS "just in case"
+    if (!p_sys->out_fmt.i_width || !p_sys->out_fmt.i_height)
+    {
+        p_sys->out_fmt.i_visible_width = p_sys->out_fmt.i_width = p_sys->sDstBufInfo->UsrData.sSystemBuffer.iWidth;
+        p_sys->out_fmt.i_visible_height = p_sys->out_fmt.i_height = p_sys->sDstBufInfo->UsrData.sSystemBuffer.iHeight;
+        p_dec->fmt_out.video.i_visible_width = p_dec->fmt_out.video.i_width = p_sys->sDstBufInfo->UsrData.sSystemBuffer.iWidth;
+        p_dec->fmt_out.video.i_visible_height = p_dec->fmt_out.video.i_height = p_sys->sDstBufInfo->UsrData.sSystemBuffer.iHeight;
+    }
+    if (p_sys->sDstBufInfo->iBufferStatus == 1) {
+        int iWidth  = p_sys->sDstBufInfo->UsrData.sSystemBuffer.iWidth;
+        int iHeight = p_sys->sDstBufInfo->UsrData.sSystemBuffer.iHeight;
+
+
+        p_picture = decoder_NewPicture(p_dec);
+        if( !p_picture ) return NULL;
+
+        unsigned long long offset = 0;
+        uint8_t*  pPtr = NULL;
+
+        // LUMA copy
+        pPtr = pData[0];
+        for (int i = 0; i < iHeight; i++){
+            memset(p_picture->p[0].p_pixels + offset, 0, iWidth);
+            memcpy(p_picture->p[0].p_pixels + offset, pPtr, iWidth);
+            pPtr += p_sys->sDstBufInfo->UsrData.sSystemBuffer.iStride[0];
+            offset += p_picture->p[0].i_pitch;
+        }
+
+        // CHROMA copy
+        iHeight /= 2;
+        iWidth /= 2;
+        offset = 0;
+        pPtr = pData[1];
+        for (int i = 0; i < iHeight; i++){
+            memset(p_picture->p[1].p_pixels + offset, 0, iWidth);
+            memcpy(p_picture->p[1].p_pixels + offset, pPtr, iWidth);
+            pPtr += p_sys->sDstBufInfo->UsrData.sSystemBuffer.iStride[1];
+            offset += p_picture->p[1].i_pitch;
+        }
+        pPtr = pData[2];
+        offset = 0;
+        for (int i = 0; i < iHeight; i++){
+            memset(p_picture->p[2].p_pixels + offset, 0, iWidth);
+            memcpy(p_picture->p[2].p_pixels + offset, pPtr, iWidth);
+            pPtr += p_sys->sDstBufInfo->UsrData.sSystemBuffer.iStride[1];
+            offset += p_picture->p[2].i_pitch;
+        }
+        p_picture->date = p_block->i_dts;
+        p_sys->sDstBufInfo->iBufferStatus = 0;
+    }
+
+    *pp_block = NULL;
+
+    if( p_block )
+        block_Release( p_block );
+    return p_picture;
+}
+
+/*****************************************************************************
+ * CloseDecoder: theora decoder destruction
+ *****************************************************************************/
+static void CloseDecoder( vlc_object_t *p_this )
+{
+    decoder_t     *p_enc = (decoder_t *)p_this;
+    decoder_sys_t *p_sys = p_enc->p_sys;
+
+    if (p_sys->pDecoder) {
+      WelsDestroyDecoder (p_sys->pDecoder);
+    }
+}
+
+/*****************************************************************************
+ * encoder_sys_t : theora encoder descriptor
+ *****************************************************************************/
+struct encoder_sys_t
+{
+    ISVCEncoder* pSVCEncoder;
+    SEncParamExt* sSvcParam;
+    uint32_t i_frame_inx;
+};
+
+/*****************************************************************************
+ * OpenEncoder: probe the encoder and return score
+ *****************************************************************************/
+static int OpenEncoder( vlc_object_t *p_this )
+{
+    encoder_t *p_enc = (encoder_t *)p_this;
+    encoder_sys_t *p_sys;
+
+    if( p_enc->fmt_out.i_codec != VLC_CODEC_H264 )
+    {
+        return VLC_EGENERIC;
+    }
+
+    /* Allocate the memory needed to store the encoder's structure */
+    if( ( p_sys = (encoder_sys_t*)malloc(sizeof(encoder_sys_t)) ) == NULL )
+        return VLC_ENOMEM;
+    p_enc->p_sys = p_sys;
+
+    p_enc->fmt_out.i_cat = VIDEO_ES;
+    p_enc->pf_encode_video = (block_t *(*)( encoder_t *p_enc, picture_t *p_pict )) Encode;
+    p_enc->pf_encode_audio = NULL;
+    p_enc->fmt_in.i_codec = VLC_CODEC_I420;
+
+    p_sys->pSVCEncoder = NULL;
+    if(WelsCreateSVCEncoder (&p_sys->pSVCEncoder))
+    {
+        msg_Err(p_enc, "WelsCreateSVCEncoder failed!");
+        return VLC_ENOMEM;
+    }
+
+    p_sys->sSvcParam = new SEncParamExt;
+    if (p_sys->sSvcParam == NULL)
+    {
+        msg_Err(p_enc, "Can't allocate memory for SEncParamExt");
+        return VLC_ENOMEM;
+    }
+
+    // TODO: set this as encoder options via VLC
+    p_sys->pSVCEncoder->GetDefaultParams(p_sys->sSvcParam);
+    p_sys->sSvcParam->iUsageType = SCREEN_CONTENT_REAL_TIME;
+    p_sys->sSvcParam->fMaxFrameRate  = 25;                // input frame rate
+    p_sys->sSvcParam->iPicWidth      = p_enc->fmt_in.video.i_width; // width of picture in samples
+    p_sys->sSvcParam->iPicHeight     = p_enc->fmt_in.video.i_height;// height of picture in samples
+    p_sys->sSvcParam->iTargetBitrate = 2500000;              // target bitrate desired
+    p_sys->sSvcParam->iMaxBitrate    = UNSPECIFIED_BIT_RATE;
+    p_sys->sSvcParam->iRCMode        = RC_QUALITY_MODE;      //  rc mode control
+    p_sys->sSvcParam->iTemporalLayerNum = 1;    // layer number at temporal level
+    p_sys->sSvcParam->iSpatialLayerNum  = 1;    // layer number at spatial level
+    p_sys->sSvcParam->bEnableDenoise    = 0;    // denoise control
+    p_sys->sSvcParam->bEnableBackgroundDetection = 0; // background detection control
+    p_sys->sSvcParam->bEnableAdaptiveQuant       = 0; // adaptive quantization control
+    p_sys->sSvcParam->bEnableFrameSkip           = 1; // frame skipping
+    p_sys->sSvcParam->bEnableLongTermReference   = 0; // long term reference control
+    p_sys->sSvcParam->uiIntraPeriod  = 25;           // period of Intra frame
+    p_sys->sSvcParam->eSpsPpsIdStrategy = CONSTANT_ID;
+    p_sys->sSvcParam->bPrefixNalAddingCtrl = 0;
+    p_sys->sSvcParam->iComplexityMode = LOW_COMPLEXITY;
+    p_sys->sSvcParam->iEntropyCodingModeFlag = 0;
+
+    p_sys->sSvcParam->sSpatialLayers[0].uiProfileIdc       = PRO_BASELINE;
+    p_sys->sSvcParam->sSpatialLayers[0].iVideoWidth        = p_enc->fmt_in.video.i_width;
+    p_sys->sSvcParam->sSpatialLayers[0].iVideoHeight       = p_enc->fmt_in.video.i_height;
+    p_sys->sSvcParam->sSpatialLayers[0].fFrameRate         = 25;
+    p_sys->sSvcParam->sSpatialLayers[0].iSpatialBitrate    = 2500000;
+    p_sys->sSvcParam->sSpatialLayers[0].iMaxSpatialBitrate    = UNSPECIFIED_BIT_RATE;
+    p_sys->sSvcParam->sSpatialLayers[0].sSliceCfg.uiSliceMode = SM_SINGLE_SLICE;
+
+    if (cmResultSuccess != p_sys->pSVCEncoder->InitializeExt(p_sys->sSvcParam)) { // SVC encoder initialization
+        printf ("SVC encoder Initialize failed\n");
+        return VLC_ENOMEM;
+    }
+
+    p_sys->i_frame_inx = 0;
+
+    msg_Info(p_enc, "OpenH264 encoder opened!");
+    return VLC_SUCCESS;
+}
+
+/****************************************************************************
+ * Encode: the whole thing
+ ****************************************************************************/
+static block_t *Encode( encoder_t *p_enc, picture_t *p_pict )
+{
+    encoder_sys_t *p_sys = p_enc->p_sys;
+
+    SSourcePicture* pSrcPic = NULL;
+    SFrameBSInfo* sFbi = NULL;
+
+    pSrcPic = new SSourcePicture;
+    if (pSrcPic == NULL) {
+        msg_Err(p_enc, "Can't allocate memory for pSrcPic");
+        return NULL;
+    }
+
+    sFbi = new SFrameBSInfo;
+    if (sFbi == NULL) {
+        msg_Err(p_enc, "Can't allocate memory for sFbi");
+        return NULL;
+    }
+
+    //fill default pSrcPic
+    pSrcPic->iColorFormat = videoFormatI420;
+    pSrcPic->uiTimeStamp = 0;
+
+    pSrcPic->iPicWidth = p_pict->format.i_width;
+    pSrcPic->iPicHeight = p_pict->format.i_height;
+
+    //update pSrcPic
+    pSrcPic->iStride[0] = p_pict->p[0].i_pitch;
+    pSrcPic->iStride[1] = p_pict->p[1].i_pitch;
+    pSrcPic->iStride[2] = p_pict->p[2].i_pitch;
+
+    pSrcPic->pData[0] = p_pict->p[0].p_pixels;
+    pSrcPic->pData[1] = p_pict->p[1].p_pixels;
+    pSrcPic->pData[2] = p_pict->p[2].p_pixels;
+
+    int iFrameSize = 0;
+
+    pSrcPic->uiTimeStamp = p_pict->date;
+    int ret = p_sys->pSVCEncoder->EncodeFrame(pSrcPic, sFbi);
+    if (cmResultSuccess != ret)
+    {
+        printf("some error in encoding :( %d\n", ret);
+        return NULL;
+    }
+    int iLayer = 0;
+    for (iLayer = 0; iLayer < sFbi->iLayerNum; iLayer++)
+    {
+        int iLayerSize = 0;
+        SLayerBSInfo* pLayerBsInfo = &sFbi->sLayerInfo[iLayer];
+        if (pLayerBsInfo != NULL) {
+            int iNalIdx = pLayerBsInfo->iNalCount - 1;
+            for (iNalIdx = pLayerBsInfo->iNalCount - 1; iNalIdx >= 0; iNalIdx--)
+            {
+                iLayerSize += pLayerBsInfo->pNalLengthInByte[iNalIdx];
+            }
+            iFrameSize += iLayerSize;
+        }
+    }
+
+    block_t *p_block;
+    p_block = block_Alloc( iFrameSize );
+    if( !p_block ) return NULL;
+
+    unsigned int i_offset = 0;
+
+    for (iLayer = 0; iLayer < sFbi->iLayerNum; iLayer++)
+    {
+        SLayerBSInfo* pLayerBsInfo = &sFbi->sLayerInfo[iLayer];
+        if (pLayerBsInfo != NULL) {
+            int iLayerSize = 0;
+            int iNalIdx = pLayerBsInfo->iNalCount - 1;
+            for (iNalIdx = pLayerBsInfo->iNalCount - 1; iNalIdx >= 0; iNalIdx--)
+            {
+                iLayerSize += pLayerBsInfo->pNalLengthInByte[iNalIdx];
+            }
+            memcpy( p_block->p_buffer + i_offset, pLayerBsInfo->pBsBuf, iLayerSize );
+            i_offset += iLayerSize;
+        }
+    }
+
+    switch (sFbi->eFrameType)
+    {
+    case videoFrameTypeIDR:
+        p_block->i_flags |= BLOCK_FLAG_TYPE_I;
+        break;
+    case videoFrameTypeI:
+    case videoFrameTypeP:
+        p_block->i_flags |= BLOCK_FLAG_TYPE_P;
+        break;
+    case videoFrameTypeSkip:
+        return NULL;
+        break;
+    default:
+        printf("DONNO HOW TO MARK THE BLOCK!\n");
+        break;
+    }
+
+    /* This isn't really valid for streams with B-frames */
+    p_block->i_length = INT64_C(1000000) *
+        p_enc->fmt_in.video.i_frame_rate_base /
+            p_enc->fmt_in.video.i_frame_rate;
+
+    p_block->i_pts = p_pict->date;
+    p_block->i_dts = p_pict->date;
+
+    return p_block;
+}
+
+/*****************************************************************************
+ * CloseEncoder: theora encoder destruction
+ *****************************************************************************/
+static void CloseEncoder( vlc_object_t *p_this )
+{
+    encoder_t     *p_enc = (encoder_t *)p_this;
+    encoder_sys_t *p_sys = p_enc->p_sys;
+
+    if (p_sys->pSVCEncoder) {
+      WelsDestroySVCEncoder (p_sys->pSVCEncoder);
+    }
+}

--- a/codec_openh264.cpp
+++ b/codec_openh264.cpp
@@ -84,7 +84,7 @@ vlc_module_begin ()
 vlc_module_end ()
 
 /*****************************************************************************
- * decoder_sys_t : theora decoder descriptor
+ * decoder_sys_t : OpenH264 decoder descriptor
  *****************************************************************************/
 struct decoder_sys_t
 {
@@ -182,6 +182,9 @@ static int OpenDecoder( vlc_object_t *p_this )
     return VLC_SUCCESS;
 }
 
+/*****************************************************************************
+ * getNal: Search for NAL units and returns it position in stream
+ *****************************************************************************/
 static size_t getNal(uint8_t* p_buf, uint8_t* p_bufEnd, uint8_t** p_nalStart, uint8_t** p_nalEnd)
 {
     *p_nalStart = p_buf;
@@ -220,7 +223,7 @@ static void getNalType(uint8_t* p_nal, int* i_type)
 }
 
 /****************************************************************************
- * DecodeBlock: the whole thing
+ * DecodeBlock: Decodes block and returnes decoded ref
  ****************************************************************************/
 static picture_t *DecodeBlock( decoder_t *p_dec, block_t **pp_block )
 {
@@ -342,7 +345,7 @@ static picture_t *DecodeBlock( decoder_t *p_dec, block_t **pp_block )
     }
 
     // walkaround for RTSP stream when picture size is availble only in PPS
-    // also it is good idea to update resolution woth new PPS "just in case"
+    // also it is good idea to update resolution with new PPS "just in case"
     if (!p_sys->out_fmt.i_width || !p_sys->out_fmt.i_height)
     {
         p_sys->out_fmt.i_visible_width = p_sys->out_fmt.i_width = p_sys->sDstBufInfo->UsrData.sSystemBuffer.iWidth;
@@ -353,7 +356,6 @@ static picture_t *DecodeBlock( decoder_t *p_dec, block_t **pp_block )
     if (p_sys->sDstBufInfo->iBufferStatus == 1) {
         int iWidth  = p_sys->sDstBufInfo->UsrData.sSystemBuffer.iWidth;
         int iHeight = p_sys->sDstBufInfo->UsrData.sSystemBuffer.iHeight;
-
 
         p_picture = decoder_NewPicture(p_dec);
         if( !p_picture ) return NULL;
@@ -401,7 +403,7 @@ static picture_t *DecodeBlock( decoder_t *p_dec, block_t **pp_block )
 }
 
 /*****************************************************************************
- * CloseDecoder: theora decoder destruction
+ * CloseDecoder: OpenH264 decoder destruction
  *****************************************************************************/
 static void CloseDecoder( vlc_object_t *p_this )
 {
@@ -414,7 +416,7 @@ static void CloseDecoder( vlc_object_t *p_this )
 }
 
 /*****************************************************************************
- * encoder_sys_t : theora encoder descriptor
+ * encoder_sys_t : OpenH264 encoder descriptor
  *****************************************************************************/
 struct encoder_sys_t
 {
@@ -502,7 +504,7 @@ static int OpenEncoder( vlc_object_t *p_this )
 }
 
 /****************************************************************************
- * Encode: the whole thing
+ * Encode: Encode frame id returnes block ref
  ****************************************************************************/
 static block_t *Encode( encoder_t *p_enc, picture_t *p_pict )
 {
@@ -613,7 +615,7 @@ static block_t *Encode( encoder_t *p_enc, picture_t *p_pict )
 }
 
 /*****************************************************************************
- * CloseEncoder: theora encoder destruction
+ * CloseEncoder: OpenH264 encoder destruction
  *****************************************************************************/
 static void CloseEncoder( vlc_object_t *p_this )
 {

--- a/codec_openh264.pro
+++ b/codec_openh264.pro
@@ -1,0 +1,85 @@
+QT =
+
+#QMAKE_CFLAGS = -x c -fvisibility=hidden
+#QMAKE_CFLAGS += -std=gnu99
+
+#QMAKE_LFLAGS += -static -static-libgcc -static-libstdc++
+
+CONFIG -= qt
+
+TARGET = libopenh264_plugin
+TEMPLATE = lib
+
+SOURCES += codec_openh264.cpp
+
+exists($$PWD/third_party/openh264-bin/openh264*.dll)|\
+exists($$PWD/third_party/openh264-bin/libopenh264*.a)|\
+exists($$PWD/third_party/openh264-bin/libopenh264*.so)|\
+exists($$PWD/third_party/openh264-bin/libopenh264*.dylib) {
+    message(Found openh264 binary library!)
+    LIBS += -L$$PWD/third_party/openh264-bin/
+    LIBS += -lopenh264
+    INCLUDEPATH += $$PWD/third_party/openh264/codec/api/svc
+} else:\
+exists($$shadowed($$PWD)/third_party/build/bin/*openh264*.dll)|\
+exists($$shadowed($$PWD)/third_party/build/lib/*openh264*.lib)|\
+exists($$shadowed($$PWD)/third_party/build/lib/*openh264*.a) {
+    message(Found openh264 compiled library!)
+    LIBS += -L$$shadowed($$PWD)/third_party/build/bin/
+    LIBS += -L$$shadowed($$PWD)/third_party/build/lib/
+    LIBS += -lopenh264
+    INCLUDEPATH += $$shadowed($$PWD)/third_party/build/include/wels
+} else {
+    CONFIG(debug, debug|release) {
+        OPENH264.buildtype = BUILDTYPE=Debug
+    } else {
+        OPENH264.buildtype = BUILDTYPE=Release
+    }
+
+    equals(QMAKE_HOST.arch, x86) {
+        OPENH264.arch = ARCH=i386
+    } else:equals(QMAKE_HOST.arch, x86_64) {
+        OPENH264.arch = ARCH=x86_64
+    } else {
+        error(UNKNOWN ARCH!)
+    }
+
+    equals(QMAKE_HOST.os, Windows) {
+        OPENH264.os = OS=mingw_nt
+    } else {
+        error(UNKNOWN OS!)
+    }
+
+    OPENH264.cd_cmd = cd $$shadowed($$PWD) && mkdir -p openh264 && cd openh264
+    OPENH264.build_cmd = make -j$$QMAKE_HOST.cpu_count -f $$PWD/third_party/openh264/Makefile $$OPENH264.buildtype $$OPENH264.arch $$OPENH264.os libraries
+    OPENH264.install_cmd = make -j$$QMAKE_HOST.cpu_count -f $$PWD/third_party/openh264/Makefile $$OPENH264.buildtype $$OPENH264.arch $$OPENH264.os install-static PREFIX=$$shadowed($$PWD)/third_party/build/
+
+    BUILD_CMD += $$escape_expand(\n)
+        BUILD_CMD += $$OPENH264.cd_cmd
+        BUILD_CMD += $$escape_expand(\n)
+        BUILD_CMD += $$OPENH264.build_cmd
+        BUILD_CMD += $$escape_expand(\n)
+        BUILD_CMD += $$OPENH264.install_cmd
+        BUILD_CMD += $$escape_expand(\n)
+
+    !system(make -v) {
+        message("$$escape_expand(\n)\
+        OpenH264 will be compiled from sources. If you dont want this - download OpenH264 compiled binary and sources (see: https://github.com/cisco/openh264/releases )\
+        and place binary in $$PWD/third_party/openh264-bin/ folder and correspondig source code to $$PWD/third_party/openh264/ folder (to include headers) and then rebuild entire project.")
+
+        third_party-build.target = third_party-build
+        third_party-build.commands = $$BUILD_CMD
+        PRE_TARGETDEPS += third_party-build
+        QMAKE_EXTRA_TARGETS += third_party-build
+    } else {
+        BUILD_CMD = $$join(BUILD_CMD, " ","$$escape_expand(\n)\
+        As your system does not have `make` in the PATH you can build OpenH264 with msys2 by copy-pasting following command and rebuild entire project:\
+        $$escape_expand(\n)\
+        Note: you can skip this step if you have already have compiled OpenH264 library or downloaded binary library version from cisco site \
+        (see: https://github.com/cisco/openh264/releases ). In this case just add binaries to $$PWD/third_party/openh264-bin/ folder and \
+        correspondig source code to $$PWD/third_party/openh264/ folder (to include headers) and then rebuild entire project)\
+        $$escape_expand(\n)"\
+        )
+        message($$BUILD_CMD)
+    }
+}

--- a/codec_openh264.pro
+++ b/codec_openh264.pro
@@ -1,17 +1,40 @@
+# Copyright (c) 2016, A.ST.I.M. S.r.l.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 QT =
 CONFIG -= qt c++11
 
-#QMAKE_CXXFLAGS = -x c -fvisibility=hidden
-#QMAKE_CFLAGS = -x c
-#QMAKE_CFLAGS += -std=C99
-
-#QMAKE_LFLAGS += -static -static-libgcc -static-libstdc++
-
-message($$CONFIG)
 TARGET = libopenh264_plugin
 TEMPLATE = lib
 
 SOURCES += codec_openh264.c
+
+DISTFILES += \
+    $$files(third_party/openh264/*.h, true) \
+    $$files(third_party/openh264/*.hpp, true) \
+    $$files(third_party/openh264/*.c, true) \
+    $$files(third_party/openh264/*.cpp, true)
 
 exists($$PWD/third_party/openh264-bin/openh264*.dll)|\
 exists($$PWD/third_party/openh264-bin/libopenh264*.a)|\
@@ -82,6 +105,7 @@ exists($$shadowed($$PWD)/third_party/build/lib/*openh264*.a) {
         $$escape_expand(\n)"\
         )
         message($$BUILD_CMD)
+        error(OpenH264 not found)
     }
 }
 

--- a/codec_openh264.pro
+++ b/codec_openh264.pro
@@ -1,32 +1,33 @@
 QT =
+CONFIG -= qt c++11
 
-#QMAKE_CFLAGS = -x c -fvisibility=hidden
-#QMAKE_CFLAGS += -std=gnu99
+#QMAKE_CXXFLAGS = -x c -fvisibility=hidden
+#QMAKE_CFLAGS = -x c
+#QMAKE_CFLAGS += -std=C99
 
 #QMAKE_LFLAGS += -static -static-libgcc -static-libstdc++
 
-CONFIG -= qt
-
+message($$CONFIG)
 TARGET = libopenh264_plugin
 TEMPLATE = lib
 
-SOURCES += codec_openh264.cpp
+SOURCES += codec_openh264.c
 
 exists($$PWD/third_party/openh264-bin/openh264*.dll)|\
 exists($$PWD/third_party/openh264-bin/libopenh264*.a)|\
 exists($$PWD/third_party/openh264-bin/libopenh264*.so)|\
 exists($$PWD/third_party/openh264-bin/libopenh264*.dylib) {
-    message(Found openh264 binary library!)
-    LIBS += -L$$PWD/third_party/openh264-bin/
+    message(Found openh264 binary library)
+    LIBS += -L"$$PWD/third_party/openh264-bin/"
     LIBS += -lopenh264
     INCLUDEPATH += $$PWD/third_party/openh264/codec/api/svc
 } else:\
 exists($$shadowed($$PWD)/third_party/build/bin/*openh264*.dll)|\
 exists($$shadowed($$PWD)/third_party/build/lib/*openh264*.lib)|\
 exists($$shadowed($$PWD)/third_party/build/lib/*openh264*.a) {
-    message(Found openh264 compiled library!)
-    LIBS += -L$$shadowed($$PWD)/third_party/build/bin/
-    LIBS += -L$$shadowed($$PWD)/third_party/build/lib/
+    message(Found openh264 compiled library)
+    LIBS += -L"$$shadowed($$PWD)/third_party/build/bin/"
+    LIBS += -L"$$shadowed($$PWD)/third_party/build/lib/"
     LIBS += -lopenh264
     INCLUDEPATH += $$shadowed($$PWD)/third_party/build/include/wels
 } else {
@@ -82,4 +83,17 @@ exists($$shadowed($$PWD)/third_party/build/lib/*openh264*.a) {
         )
         message($$BUILD_CMD)
     }
+}
+
+# TODO: Add vlc bin check
+exists($$PWD/third_party/vlc-dist/libvlccore.dll):\
+exists($$PWD/third_party/vlc-dist/libvlc.dll):\
+exists($$PWD/third_party/vlc-dist/sdk/include):{
+    message(Found vlc dist package)
+    LIBS += -L"$$PWD/third_party/vlc-dist/"
+    LIBS += -lvlc -lvlccore
+    INCLUDEPATH += $$PWD/third_party/vlc-dist/sdk/include
+    INCLUDEPATH += $$PWD/third_party/vlc-dist/sdk/include/vlc/plugins/
+} else {
+
 }

--- a/third_party/openh264-bin/.gitignore
+++ b/third_party/openh264-bin/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/third_party/vlc-dist/.gitignore
+++ b/third_party/vlc-dist/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
- Decoding:
  - Add OpenH264 decoder usage to VLC
  - Add NAL unit type parsing to handle packets with non-integral NAL units
  - Add non-integral NAL unit handling (storing NAL in memory between two NAL delimiters)
  - Add PPS NAL handling for updating resolution
- Encoding:
  - Add OpenH264 encoder usage to VLC
  - Add default options to encoder (real-time screen content with 25 I-frame period and 2500000 bitrate)
- General:
  - Add module name
  - Add OpenH264 version check
  - Add OpenH264-VLC log passing
- General (non-codec)
  - Add Qt project file
  - Add OpenH264 submodule reference
  - Add OpenH264 compile commands to Qt project
  - Add OpenH264 bin detection to Qt project
  - Add VLC sdk detection
